### PR TITLE
make Python 3 and numpy-1.13 compatible

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -40,7 +40,7 @@ draw 100 samples from :math:`\mathrm{Pr}(\xi)`::
 
     def rejection_sample(p, pmax, prop, size):
         out=[]
-        for s in xrange(size):
+        for s in range(size):
             x = prop()
             px = p(x)
             pu = np.random.uniform(low=0.0, high=pmax)
@@ -141,7 +141,7 @@ the data and some samples from the Bayesian posterior on the same graph::
     ax = fig.add_subplot(122)
     ax.scatter(x, y, alpha=0.5)
     ax.errorbar(x, y, xerr=xsig, yerr=ysig, ls=' ', alpha=0.5)
-    for i in xrange(0, len(lm.chain), 25):
+    for i in range(0, len(lm.chain), 25):
         xs = np.arange(-10,11)
         ys = lm.chain[i]['alpha'] + xs * lm.chain[i]['beta']
         ax.plot(xs, ys, color='r', alpha=0.02)
@@ -184,11 +184,11 @@ results::
     ax = fig.add_subplot(122)
     ax.errorbar(x[delta], ycens[delta], xsig[delta], ysig[delta], ls=' ', alpha=0.4)
     ax.errorbar(x[notdelta], ycens[notdelta], yerr=0.3, uplims=np.ones(sum(notdelta), dtype=bool), ls=' ', c='b', alpha=0.4)
-    for i in xrange(0, len(lmcens.chain), 25):
+    for i in range(0, len(lmcens.chain), 25):
         xs = np.arange(-10, 11)
         ys = lmcens.chain[i]['alpha'] + xs * lmcens.chain[i]['beta']
         ax.plot(xs, ys, color='g', alpha=0.02)
-    for i in xrange(0, len(lm.chain), 25):
+    for i in range(0, len(lm.chain), 25):
         xs = np.arange(-10, 11)
         ys = lm.chain[i]['alpha'] + xs * lm.chain[i]['beta']
         ax.plot(xs, ys, color='r', alpha=0.02)

--- a/linmix/__init__.py
+++ b/linmix/__init__.py
@@ -1,4 +1,6 @@
 """ A hierarchical Bayesian approach to linear regression with error in both X and Y.
 """
 
-from linmix import LinMix
+__all__ = ['linmix']
+
+from .linmix import LinMix

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
In Python 3

- print is a function
- range returns an iterator like xrange, which exists only in Python 2
- imports are absolute

In numpy-1.13 floats are no longer accepted to describe array shapes